### PR TITLE
Fixes #58 - Trigger noSpaces validation only if the string length > 0

### DIFF
--- a/src/ReactPasswordChecklist.test.tsx
+++ b/src/ReactPasswordChecklist.test.tsx
@@ -293,20 +293,28 @@ describe("ReactPasswordChecklist Test Suite", () => {
 			const result = mount(<ReactPasswordChecklist rules={["noSpaces"]} value="Idonthavespaces" />)
 			expect(result.find("li").hasClass("valid")).toBeTruthy()
 		})
-		it("Sets invalid for space", () => {
-			const result = mount(<ReactPasswordChecklist rules={["noSpaces"]} value="I have spaces" />)
-			expect(result.find("li").hasClass("invalid")).toBeTruthy()
-		})
 		it("Sets invalid for an empty value", () => {
 			const result = mount(<ReactPasswordChecklist rules={["noSpaces"]} value="" />)
 			expect(result.find("li").hasClass("invalid")).toBeTruthy()
 		})
-		it("Sets invalid for tab spaces", () => {
+		it("Sets invalid for space (' ') ", () => {
+			const result = mount(<ReactPasswordChecklist rules={["noSpaces"]} value="I have spaces" />)
+			expect(result.find("li").hasClass("invalid")).toBeTruthy()
+		})
+		it("Sets invalid for tab space character (\t)", () => {
 			const result = mount(<ReactPasswordChecklist rules={["noSpaces"]} value={`ihave\tatabspace`} />)
 			expect(result.find("li").hasClass("invalid")).toBeTruthy()
 		})
-		it("Sets invalid for new lines", () => {
+		it("Sets invalid for new line character (\n)", () => {
 			const result = mount(<ReactPasswordChecklist rules={["noSpaces"]} value={`Ihave\nanewline`} />)
+			expect(result.find("li").hasClass("invalid")).toBeTruthy()
+		})
+		it("Sets invalid for carriage return character (\r)", () => {
+			const result = mount(<ReactPasswordChecklist rules={["noSpaces"]} value={`Ihaveacarriage\rreturn`} />)
+			expect(result.find("li").hasClass("invalid")).toBeTruthy()
+		})
+		it("Sets invalid for form feed character (\f)", () => {
+			const result = mount(<ReactPasswordChecklist rules={["noSpaces"]} value={`Ihavea\fformfeed`} />)
 			expect(result.find("li").hasClass("invalid")).toBeTruthy()
 		})
 	})

--- a/src/ReactPasswordChecklist.test.tsx
+++ b/src/ReactPasswordChecklist.test.tsx
@@ -289,10 +289,6 @@ describe("ReactPasswordChecklist Test Suite", () => {
 			const result = mount(<ReactPasswordChecklist rules={["noSpaces"]} value="" />)
 			expect(result.find("span").text()).toEqual("Password contains no spaces.")
 		})
-		it("Sets invalid for an empty value", () => {
-			const result = mount(<ReactPasswordChecklist rules={["noSpaces"]} value="" />)
-			expect(result.find("li").hasClass("invalid")).toBeTruthy()
-		})
 		it("Sets invalid", () => {
 			const result = mount(<ReactPasswordChecklist rules={["noSpaces"]} value="I have spaces" />)
 			expect(result.find("li").hasClass("invalid")).toBeTruthy()
@@ -300,6 +296,18 @@ describe("ReactPasswordChecklist Test Suite", () => {
 		it("Sets valid", () => {
 			const result = mount(<ReactPasswordChecklist rules={["noSpaces"]} value="Idonthavespaces" />)
 			expect(result.find("li").hasClass("valid")).toBeTruthy()
+		})
+		it("Sets invalid for an empty value", () => {
+			const result = mount(<ReactPasswordChecklist rules={["noSpaces"]} value="" />)
+			expect(result.find("li").hasClass("invalid")).toBeTruthy()
+		})
+		it("Sets invalid for tab spaces", () => {
+			const result = mount(<ReactPasswordChecklist rules={["noSpaces"]} value={`ihave\tatabspace`} />)
+			expect(result.find("li").hasClass("invalid")).toBeTruthy()
+		})
+		it("Sets invalid for new lines", () => {
+			const result = mount(<ReactPasswordChecklist rules={["noSpaces"]} value={`Ihave\nanewline`} />)
+			expect(result.find("li").hasClass("invalid")).toBeTruthy()
 		})
 	})
 	describe("capitalAndLowercase", () => {

--- a/src/ReactPasswordChecklist.test.tsx
+++ b/src/ReactPasswordChecklist.test.tsx
@@ -289,6 +289,10 @@ describe("ReactPasswordChecklist Test Suite", () => {
 			const result = mount(<ReactPasswordChecklist rules={["noSpaces"]} value="" />)
 			expect(result.find("span").text()).toEqual("Password contains no spaces.")
 		})
+		it("Sets invalid for an empty value", () => {
+			const result = mount(<ReactPasswordChecklist rules={["noSpaces"]} value="" />)
+			expect(result.find("li").hasClass("invalid")).toBeTruthy()
+		})
 		it("Sets invalid", () => {
 			const result = mount(<ReactPasswordChecklist rules={["noSpaces"]} value="I have spaces" />)
 			expect(result.find("li").hasClass("invalid")).toBeTruthy()

--- a/src/ReactPasswordChecklist.test.tsx
+++ b/src/ReactPasswordChecklist.test.tsx
@@ -289,13 +289,13 @@ describe("ReactPasswordChecklist Test Suite", () => {
 			const result = mount(<ReactPasswordChecklist rules={["noSpaces"]} value="" />)
 			expect(result.find("span").text()).toEqual("Password contains no spaces.")
 		})
-		it("Sets invalid", () => {
-			const result = mount(<ReactPasswordChecklist rules={["noSpaces"]} value="I have spaces" />)
-			expect(result.find("li").hasClass("invalid")).toBeTruthy()
-		})
 		it("Sets valid", () => {
 			const result = mount(<ReactPasswordChecklist rules={["noSpaces"]} value="Idonthavespaces" />)
 			expect(result.find("li").hasClass("valid")).toBeTruthy()
+		})
+		it("Sets invalid for space", () => {
+			const result = mount(<ReactPasswordChecklist rules={["noSpaces"]} value="I have spaces" />)
+			expect(result.find("li").hasClass("invalid")).toBeTruthy()
 		})
 		it("Sets invalid for an empty value", () => {
 			const result = mount(<ReactPasswordChecklist rules={["noSpaces"]} value="" />)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -136,7 +136,7 @@ const ReactPasswordChecklist: React.FC<ReactPasswordChecklistProps> = ({
 			message: messages.notEmpty || "Password fields are not empty.",
 		},
 		noSpaces: {
-			valid: !value.includes(" "),
+			valid: Boolean(value.length > 0 && !/\s/.test(value)),
 			message: messages.noSpaces || "Password contains no spaces.",
 		},
 	}


### PR DESCRIPTION
@sators to give you an overview of what I've done -

- [x] Switched to /\s/ to check for ALL whitespace characters (spaces, tab spaces, newlines, form feeds, carriage returns)
- [x] Added test to show how an empty value will now show "invalid".
- [x] Added separate tests for each of those characters

#### Why a regex `/\s/` over " " ?

It is technically impossible to type in any of the characters except for spaces - however, it is possible to paste something like that in OR have these characters in a string that's being pulled from an external source (for controlled components). 

Using the regex locks it down pretty well, in my opinion.
